### PR TITLE
Add support for custom segment colors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,11 @@ class ReactSpeedometer extends React.Component {
                 parentHeight: self.gaugeDiv.parentNode.clientHeight
             };
 
+            var segmentColorFn = PROPS.segmentColors && PROPS.segmentColors.length === PROPS.segments ?
+                PROPS.segmentColors : d3InterpolateHsl(
+                    d3Rgb( PROPS.startColor ),
+                    d3Rgb( PROPS.endColor )
+                )
             // START: Configurable values
             var config = {
                 // width/height config
@@ -158,10 +163,7 @@ class ReactSpeedometer extends React.Component {
                 // segments in the speedometer
                 majorTicks: PROPS.segments,
                 // color range for the segments
-                arcColorFn: d3InterpolateHsl( 
-                                d3Rgb( PROPS.startColor ), 
-                                d3Rgb( PROPS.endColor ) 
-                            ),
+                arcColorFn: segmentColorFn,
                 // needle configuration
                 needleTransition: PROPS.needleTransition,
                 needleTransitionDuration: PROPS.needleTransitionDuration,
@@ -272,7 +274,10 @@ class ReactSpeedometer extends React.Component {
                         .append('path')
                         .attr('class', 'speedo-segment')
                         .attr('fill', function(d, i) {
-                            return config.arcColorFn(d * i);
+                            if (typeof config.arcColorFn === 'function') {
+                                return config.arcColorFn(d * i);
+                            }
+                            return config.arcColorFn[i];
                         })
                         .attr('d', arc);
 

--- a/src/tests/index.js
+++ b/src/tests/index.js
@@ -49,6 +49,17 @@ describe("<ReactSpeedometer />", () => {
         expect( full_dom_wrapper.find('path.speedo-segment').length ).to.equal(5);
     });
 
+    // check if the segments have the correct color
+    it('should use the given segment colors', () => {
+        const full_dom_wrapper = mount( <ReactSpeedometer
+            segments={3}
+            segmentColors={['#ff0000', '#00ff00', '#0000ff']}
+        /> ).render();
+        expect( full_dom_wrapper.find('path.speedo-segment')[0].attribs.fill ).to.equal('#ff0000');
+        expect( full_dom_wrapper.find('path.speedo-segment')[1].attribs.fill ).to.equal('#00ff00');
+        expect( full_dom_wrapper.find('path.speedo-segment')[2].attribs.fill ).to.equal('#0000ff');
+    });
+
     // check the text color of the current value is the default (#666)
     it('should have the default text color for current value', () => {
         const full_dom_wrapper = mount( <ReactSpeedometer /> ).render();


### PR DESCRIPTION
Sometimes you need to change the segments colors and do not want to rely
on the `d3InterpolateHSL()` function. You should be able to provide the
colors as a prop.

If the user now provides the `segmentColors` prop as an array of colors,
and it has the same length as the number of segments, we use the
provided colors for the segments.

It could be possible to change the code to provide another color
function, but since this wasn't necessary this time, I didn't add it.